### PR TITLE
Corrected example to be named servers

### DIFF
--- a/SS3-Unified_Credentials_File.md
+++ b/SS3-Unified_Credentials_File.md
@@ -46,7 +46,7 @@ It may have a top level `configs` object that contains individual app specific c
 ## Full Example
 
 ```yaml
-connections:
+servers:
   main:
     host: screeps.com
     secure: true


### PR DESCRIPTION
`screeps-api` looks for servers and not `connections`, earlier format definitions also states that the top level should be called `servers`